### PR TITLE
Add noise attack script

### DIFF
--- a/adversarial_codegen/noise.py
+++ b/adversarial_codegen/noise.py
@@ -1,0 +1,270 @@
+# Standard library imports
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+# Third-party imports
+import bitsandbytes as bnb
+import fire
+import numpy as np
+import torch
+import torch.nn as nn
+from evalplus.data import get_human_eval_plus, get_mbpp_plus, write_jsonl
+from tqdm import tqdm
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+    GenerationConfig,
+)
+
+from adversarial_codegen.utils import extract_functions
+
+
+@dataclass
+class ModelConfig:
+    model_path: str
+    quantization: Optional[str] = None  # '4bit', '8bit', or None
+    device_map: str = 'auto'
+
+
+class NoiseConfig:
+    def __init__(self, noise_type: str = "gaussian", noise_level: float = 1e-3):
+        self.noise_type = noise_type
+        self.noise_level = noise_level
+        self._validate()
+    
+    def _validate(self):
+        valid_noise_types = ["uniform", "gaussian"]
+        if self.noise_type not in valid_noise_types:
+            raise ValueError(f"Noise type must be one of {valid_noise_types}")
+        if self.noise_level < 0:
+            raise ValueError("Noise level must be positive")
+
+
+class LLMEvaluator:
+    def __init__(self, model_config: ModelConfig):
+        self.model_config = model_config
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._setup_model()
+        
+    def _setup_model(self):
+        """Setup model with or without quantization"""
+        # Setup quantization configuration if specified
+        if self.model_config.quantization is None:
+            # Load original model without quantization
+            print("Loading original model...")
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.model_config.model_path,
+                device_map=self.model_config.device_map
+            )
+        else:
+            # Setup quantization configuration
+            if self.model_config.quantization == '4bit':
+                print("Loading quantized model with 4-bit quantization...")
+                quantization_config = BitsAndBytesConfig(
+                    load_in_4bit=True,
+                    bnb_4bit_quant_type="nf4",
+                    bnb_4bit_use_double_quant=True,
+                    bnb_4bit_compute_dtype=torch.float32,
+                )
+            elif self.model_config.quantization == '8bit':
+                print("Loading quantized model with 8-bit quantization...")
+                quantization_config = BitsAndBytesConfig(
+                    load_in_8bit=True,
+                )
+            else:
+                raise ValueError(f"Unsupported quantization type: {self.model_config.quantization}")
+            
+            # Load quantized model
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.model_config.model_path,
+                quantization_config=quantization_config,
+                device_map=self.model_config.device_map,
+                torch_dtype=torch.float32 if self.model_config.quantization == '4bit' else torch.float16,
+            )
+        
+        # Load tokenizer (same for both original and quantized models)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_config.model_path)
+        
+    def add_noise(self, noise_config: NoiseConfig):
+        """Add noise to model parameters"""
+        with torch.no_grad():
+            for param in self.model.parameters():
+                if param.requires_grad:
+                    if noise_config.noise_type == 'gaussian':
+                        noise = torch.randn_like(param).to(param.device) * noise_config.noise_level
+                    else:  # uniform
+                        noise = (torch.rand_like(param).to(param.device) * 2 - 1) * noise_config.noise_level
+                    param.add_(noise)
+    
+    def generate(self, prompt: str, generation_config: Optional[GenerationConfig] = None) -> str:
+        """Generate text from prompt"""
+        if generation_config is None:
+            generation_config = GenerationConfig(
+                max_length=500,
+                do_sample=False,
+                num_return_sequences=1,
+            )
+        
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        outputs = self.model.generate(
+            **inputs,
+            generation_config=generation_config,
+            pad_token_id=self.tokenizer.eos_token_id
+        )
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+
+class LLMEvaluationCLI:
+    """Command line interface for LLM evaluation with noise analysis"""
+    
+    @staticmethod
+    def _prepare_output_file(output_path: str):
+        """Prepare the output file and its directory.
+        
+        Args:
+            output_path: Path where results will be saved
+            
+        Returns:
+            Path object of the prepared output file
+        """
+        output_path = Path(output_path)
+        
+        # Create output directory if it doesn't exist
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Clear existing file if it exists
+        if output_path.exists():
+            output_path.unlink()
+            
+        return output_path
+    
+    @staticmethod
+    def evaluate_single_model(
+        model_path: str,
+        output_path: str = "results.jsonl",
+        quantization: Optional[str] = None,
+        noise_type: str = "uniform",
+        noise_level: float = 1e-3,
+        device_map: str = "auto",
+        max_length: int = 500,
+        num_return_sequences: int = 1,
+        do_sample: bool = False
+    ):
+        """
+        Evaluate a single model with specified configurations.
+        
+        Args:
+            model_path: Path to the model
+            output_path: Path to save results
+            quantization: Quantization type ('4bit', '8bit', or None)
+            noise_type: Type of noise to add ('uniform' or 'gaussian')
+            noise_level: Level of noise to add
+            device_map: Device mapping strategy
+            max_length: Maximum length for generation
+            num_return_sequences: Number of sequences to return
+            do_sample: Whether to use sampling for generation
+        """
+        # Prepare output file and directory
+        output_path = LLMEvaluationCLI._prepare_output_file(output_path)
+        
+        # Load prompts
+        mbpp_problems = get_mbpp_plus()
+        problems_to_eval = list(mbpp_problems.items())
+
+        # Setup configurations
+        model_config = ModelConfig(model_path, quantization, device_map)
+        noise_config = NoiseConfig(noise_type, noise_level)
+        generation_config = GenerationConfig(
+            max_length=max_length,
+            do_sample=do_sample,
+            num_return_sequences=num_return_sequences,
+        )
+        
+        # Initialize evaluator
+        noised_evaluator = LLMEvaluator(model_config)
+        noised_evaluator.add_noise(noise_config)
+        
+        # Process each prompt
+        results = []
+        for task_id, problem in tqdm(problems_to_eval):
+            
+            prompt = problem["prompt"]
+            
+            # Generate with noise
+            noised_generation = noised_evaluator.generate(prompt, generation_config)
+            gen_solution = extract_functions(noised_generation[len(prompt):].lstrip())
+            
+            result = {
+                "task_id": task_id,
+                "solution": gen_solution,
+            }
+            
+            results.append(result)
+            
+            # Write result to file
+            with open(output_path, 'a') as f:
+                f.write(json.dumps(result) + '\n')
+        
+        return f"Evaluation completed. Results saved to {output_path}"
+    
+    @staticmethod
+    def evaluate_multiple_models(
+        model_paths: List[str],
+        prompt_file: str,
+        output_path: str = "results.jsonl",
+        quantizations: Optional[List[str]] = None,
+        noise_types: List[str] = ["uniform"],
+        noise_levels: List[float] = [1e-4],
+        device_map: str = "auto",
+        max_length: int = 500,
+        do_sample: bool = False
+    ):
+        """
+        Evaluate multiple models with different configurations.
+        
+        Args:
+            model_paths: List of paths to models
+            prompt_file: Path to file containing prompts (one per line)
+            output_path: Path to save results
+            quantizations: List of quantization types for each model
+            noise_types: List of noise types to test
+            noise_levels: List of noise levels to test
+            device_map: Device mapping strategy
+            max_length: Maximum length for generation
+            do_sample: Whether to use sampling for generation
+        """
+        # Prepare output file and directory
+        output_path = LLMEvaluationCLI._prepare_output_file(output_path)
+        
+        if quantizations is None:
+            quantizations = [None] * len(model_paths)
+        
+        for model_path, quantization in zip(model_paths, quantizations):
+            for noise_type in noise_types:
+                for noise_level in noise_levels:
+                    print(f"Evaluating model: {model_path} with {noise_type} noise at level {noise_level}")
+                    LLMEvaluationCLI.evaluate_single_model(
+                        model_path=model_path,
+                        prompt_file=prompt_file,
+                        output_path=output_path,
+                        quantization=quantization,
+                        noise_type=noise_type,
+                        noise_level=noise_level,
+                        device_map=device_map,
+                        max_length=max_length,
+                        do_sample=do_sample
+                    )
+        
+        return f"Evaluation completed for all models. Results saved to {output_path}"
+
+
+def main():
+    fire.Fire(LLMEvaluationCLI)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_noise.sh
+++ b/scripts/run_noise.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+# Default values
+MODEL_NAME="Llama-3.2-3B"
+NOISE_TYPE="gaussian"
+MODEL_PATH="/home/wding8/models/${MODEL_NAME}"
+OUTPUT_DIR="/home/wding8/RQ1_results/noise_attack"
+MAX_PARALLEL=4  # Default maximum parallel processes
+
+# Function to display script usage
+usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --model_name MODEL_NAME    Model name (default: Llama-3.2-3B)"
+  echo "  --noise_type NOISE_TYPE    Noise type: gaussian or uniform (default: gaussian)"
+  echo "  --max_parallel N           Maximum number of parallel processes (default: 4)"
+  echo "  --help                     Display this help message"
+  echo ""
+  echo "The script will loop through:"
+  echo "  - Quantization: None, 8bit, 4bit"
+  echo "  - Noise levels: 1e-4, 1e-3, 3e-3, 5e-3, 1e-2"
+  exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --model_name)
+      MODEL_NAME="$2"
+      MODEL_PATH="/home/wding8/models/${MODEL_NAME}"
+      shift 2
+      ;;
+    --noise_type)
+      if [[ "$2" == "gaussian" || "$2" == "uniform" ]]; then
+        NOISE_TYPE="$2"
+        shift 2
+      else
+        echo "Error: Noise type must be 'gaussian' or 'uniform'"
+        usage
+      fi
+      ;;
+    --max_parallel)
+      if [[ "$2" =~ ^[0-9]+$ ]]; then
+        MAX_PARALLEL="$2"
+        shift 2
+      else
+        echo "Error: Max parallel must be a positive integer"
+        usage
+      fi
+      ;;
+    --help)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Create a short abbreviation for the noise type to use in filenames
+if [[ "$NOISE_TYPE" == "gaussian" ]]; then
+  NOISE_ABBR="gs"
+else
+  NOISE_ABBR="un"
+fi
+
+# Array of quantization options to loop through
+QUANTIZATIONS=("None" "8bit" "4bit")
+
+# Array of noise levels to loop through
+NOISE_LEVELS=("1e-4" "1e-3" "3e-3" "5e-3" "1e-2")
+
+# Create a log directory
+LOG_DIR="${OUTPUT_DIR}/logs"
+mkdir -p "$LOG_DIR"
+
+# Create a temp directory for job tracking
+TEMP_DIR="${OUTPUT_DIR}/tmp"
+mkdir -p "$TEMP_DIR"
+
+# Create a file to track running jobs
+TRACKING_FILE="${TEMP_DIR}/running_jobs.txt"
+> "$TRACKING_FILE"  # Empty the file
+
+# Function to count currently running jobs
+count_running_jobs() {
+  # Count lines in the tracking file that contain PIDs of running processes
+  local count=0
+  local to_remove=()
+  
+  # If file doesn't exist yet, return 0
+  if [[ ! -f "$TRACKING_FILE" ]]; then
+    return 0
+  fi
+  
+  # Read the file line by line
+  while IFS= read -r line; do
+    local pid=$(echo "$line" | awk '{print $1}')
+    
+    # Check if the process is still running
+    if ps -p "$pid" >/dev/null 2>&1; then
+      ((count++))
+    else
+      # Mark this line for removal
+      to_remove+=("$line")
+    fi
+  done < "$TRACKING_FILE"
+  
+  # Remove completed jobs from tracking file
+  if [[ ${#to_remove[@]} -gt 0 ]]; then
+    for job in "${to_remove[@]}"; do
+      # Use sed to remove the exact line
+      sed -i "\|^$job$|d" "$TRACKING_FILE"
+      echo "Job completed: $job"
+    done
+  fi
+  
+  return $count
+}
+
+# Function to wait for an available slot
+wait_for_slot() {
+  while true; do
+    count_running_jobs
+    local running=$?
+    
+    if [[ $running -lt $MAX_PARALLEL ]]; then
+      return
+    fi
+    
+    echo "Maximum parallel jobs ($MAX_PARALLEL) reached. Currently running: $running. Waiting..."
+    sleep 10
+  done
+}
+
+# Function to run evaluation
+run_evaluation() {
+  local quant="$1"
+  local noise_level="$2"
+  
+  # Prepare output file path with appropriate naming convention
+  if [[ "$quant" == "None" ]]; then
+    quant_suffix="base"
+    quant_arg=""
+  else
+    quant_suffix="${quant:0:1}bnb"
+    quant_arg="--quantization $quant"
+  fi
+  
+  local job_id="${MODEL_NAME}-${quant_suffix}-${NOISE_ABBR}-${noise_level}"
+  output_path="${OUTPUT_DIR}/${job_id}/results.jsonl"
+  log_file="${LOG_DIR}/${job_id}.log"
+  
+  # Create output directory if it doesn't exist
+  mkdir -p "$(dirname "$output_path")"
+  
+  # Log the command that will be executed
+  echo "Starting job: $job_id"
+  
+  # Create job script for this specific task
+  local job_script="${LOG_DIR}/job_${job_id}.sh"
+  cat > "$job_script" << EOF
+#!/bin/bash
+echo "Starting job at \$(date)" > "$log_file"
+echo "Command: adversarial-codegen-noise evaluate_single_model --model_path $MODEL_PATH $quant_arg --output_path $output_path --noise_type $NOISE_TYPE --noise_level $noise_level" >> "$log_file"
+
+adversarial-codegen-noise evaluate_single_model \\
+  --model_path $MODEL_PATH \\
+  $quant_arg \\
+  --output_path $output_path \\
+  --noise_type $NOISE_TYPE \\
+  --noise_level $noise_level \\
+  >> "$log_file" 2>&1
+
+echo "Job completed at \$(date)" >> "$log_file"
+
+# Remove this job from the tracking file when done
+sed -i "\|^[0-9]\\+ $job_id$|d" "$TRACKING_FILE"
+EOF
+
+  chmod +x "$job_script"
+  
+  # Run the job script in background using nohup
+  nohup "$job_script" > /dev/null 2>&1 &
+  local pid=$!
+  
+  # Verify that the process is actually running
+  sleep 1
+  if ! ps -p "$pid" >/dev/null 2>&1; then
+    echo "WARNING: Process for $job_id failed to start or terminated immediately!"
+    return 1
+  fi
+  
+  # Add to the tracking file
+  echo "$pid $job_id" >> "$TRACKING_FILE"
+  
+  echo "  PID: $pid"
+  echo "  Output: $output_path"
+  echo "  Log: $log_file"
+  
+  return 0
+}
+
+# Main execution
+echo "Starting evaluation for model: $MODEL_NAME with noise type: $NOISE_TYPE"
+echo "Will loop through quantizations: ${QUANTIZATIONS[*]}"
+echo "Will loop through noise levels: ${NOISE_LEVELS[*]}"
+echo "Maximum parallel processes: $MAX_PARALLEL"
+echo "----------------------------------------"
+
+# Loop through each quantization and noise level combination
+total_jobs=$((${#QUANTIZATIONS[@]} * ${#NOISE_LEVELS[@]}))
+completed_jobs=0
+
+for quant in "${QUANTIZATIONS[@]}"; do
+  for noise_level in "${NOISE_LEVELS[@]}"; do
+    # Wait until we have fewer than MAX_PARALLEL running jobs
+    wait_for_slot
+    
+    # Run the evaluation
+    run_evaluation "$quant" "$noise_level"
+    
+    # Count jobs
+    ((completed_jobs++))
+    echo "Scheduled job $completed_jobs/$total_jobs"
+    echo "----------------------------------------"
+    
+    # Brief pause to ensure process starts properly
+    sleep 1
+  done
+done
+
+echo "All jobs scheduled. Waiting for remaining jobs to complete..."
+
+# Wait until all jobs are done
+while true; do
+  count_running_jobs
+  running=$?
+  
+  if [[ $running -eq 0 ]]; then
+    break
+  fi
+  
+  echo "Still waiting on $running process(es)..."
+  sleep 15
+done
+
+echo "All evaluations completed for $MODEL_NAME with noise type $NOISE_TYPE"

--- a/scripts/run_noise.sh
+++ b/scripts/run_noise.sh
@@ -1,68 +1,206 @@
 #!/bin/bash
 
 # Default values
-MODEL_NAME="Llama-3.2-3B"
+MODEL_NAME="Llama-3.2-1B"
 NOISE_TYPE="gaussian"
-MODEL_PATH="/home/wding8/models/${MODEL_NAME}"
-OUTPUT_DIR="/home/wding8/RQ1_results/noise_attack"
+BASE_DIR="${HOME}"  # Default to user's home directory
+MODEL_PATH="${BASE_DIR}/models/${MODEL_NAME}"
+OUTPUT_DIR="${BASE_DIR}/RQ1_results/noise_attack"
 MAX_PARALLEL=4  # Default maximum parallel processes
+
+# Dictionary of model mappings
+declare -A MODEL_REPOS=(
+    ["Llama-3.2-1B"]="meta-llama/Llama-3.2-1B"
+    ["Llama-3.2-3B"]="meta-llama/Llama-3.2-3B"
+    ["starcoder2-3b"]="bigcode/starcoder2-3b"
+    ["starcoder2-7b"]="bigcode/starcoder2-7b"
+    ["starcoder2-15b"]="bigcode/starcoder2-15b"
+    ["codegen-350M-mono"]="Salesforce/codegen-350M-mono"
+    ["codegen-2B-mono"]="Salesforce/codegen-2B-mono"
+    ["codegen-6B-mono"]="Salesforce/codegen-6B-mono"
+)
 
 # Function to display script usage
 usage() {
-  echo "Usage: $0 [options]"
-  echo "Options:"
-  echo "  --model_name MODEL_NAME    Model name (default: Llama-3.2-3B)"
-  echo "  --noise_type NOISE_TYPE    Noise type: gaussian or uniform (default: gaussian)"
-  echo "  --max_parallel N           Maximum number of parallel processes (default: 4)"
-  echo "  --help                     Display this help message"
-  echo ""
-  echo "The script will loop through:"
-  echo "  - Quantization: None, 8bit, 4bit"
-  echo "  - Noise levels: 1e-4, 1e-3, 3e-3, 5e-3, 1e-2"
-  exit 1
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --model_name MODEL_NAME    Model name (default: Llama-3.2-1B)"
+    echo "  --noise_type NOISE_TYPE    Noise type: gaussian or uniform (default: gaussian)"
+    echo "  --max_parallel N           Maximum number of parallel processes (default: 4)"
+    echo "  --base_dir DIR            Base directory for all operations (default: \$HOME)"
+    echo "  --setup_only              Only perform setup and model download, skip evaluation"
+    echo "  --help                    Display this help message"
+    echo ""
+    echo "Supported models:"
+    for model in "${!MODEL_REPOS[@]}"; do
+        echo "  - $model"
+    done
+    exit 1
 }
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
-  case $1 in
-    --model_name)
-      MODEL_NAME="$2"
-      MODEL_PATH="/home/wding8/models/${MODEL_NAME}"
-      shift 2
-      ;;
-    --noise_type)
-      if [[ "$2" == "gaussian" || "$2" == "uniform" ]]; then
-        NOISE_TYPE="$2"
-        shift 2
-      else
-        echo "Error: Noise type must be 'gaussian' or 'uniform'"
-        usage
-      fi
-      ;;
-    --max_parallel)
-      if [[ "$2" =~ ^[0-9]+$ ]]; then
-        MAX_PARALLEL="$2"
-        shift 2
-      else
-        echo "Error: Max parallel must be a positive integer"
-        usage
-      fi
-      ;;
-    --help)
-      usage
-      ;;
-    *)
-      echo "Unknown option: $1"
-      usage
-      ;;
-  esac
+    case $1 in
+        --model_name)
+            MODEL_NAME="$2"
+            MODEL_PATH="${BASE_DIR}/models/${MODEL_NAME}"
+            shift 2
+            ;;
+        --noise_type)
+            if [[ "$2" == "gaussian" || "$2" == "uniform" ]]; then
+                NOISE_TYPE="$2"
+                shift 2
+            else
+                echo "Error: Noise type must be 'gaussian' or 'uniform'"
+                usage
+            fi
+            ;;
+        --max_parallel)
+            if [[ "$2" =~ ^[0-9]+$ ]]; then
+                MAX_PARALLEL="$2"
+                shift 2
+            else
+                echo "Error: Max parallel must be a positive integer"
+                usage
+            fi
+            ;;
+        --base_dir)
+            BASE_DIR="$2"
+            MODEL_PATH="${BASE_DIR}/models/${MODEL_NAME}"
+            OUTPUT_DIR="${BASE_DIR}/RQ1_results/noise_attack"
+            shift 2
+            ;;
+        --setup_only)
+            SETUP_ONLY=true
+            shift
+            ;;
+        --help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
 done
+
+# Validate model name
+if [[ ! "${MODEL_REPOS[$MODEL_NAME]}" ]]; then
+    echo "Error: Invalid model name: $MODEL_NAME"
+    echo "Supported models:"
+    for model in "${!MODEL_REPOS[@]}"; do
+        echo "  - $model"
+    done
+    exit 1
+fi
+
+# Setup function
+setup_environment() {
+    echo "Setting up environment..."
+    
+    # Create necessary directories
+    mkdir -p "${BASE_DIR}/models"
+    
+    # Navigate to the project directory
+    cd "${BASE_DIR}/adversarial-codegen" || {
+        echo "Error: Could not find adversarial-codegen directory"
+        exit 1
+    }
+    
+    # Create and activate conda environment
+    conda create -n adversarial-codegen python=3.10 -y || {
+        echo "Error: Failed to create conda environment"
+        exit 1
+    }
+    
+    # Source conda for script environment
+    source "$(conda info --base)/etc/profile.d/conda.sh"
+    
+    # Activate the environment
+    conda activate adversarial-codegen || {
+        echo "Error: Failed to activate conda environment"
+        exit 1
+    }
+    
+    # Install dependencies
+    pip install uv || {
+        echo "Error: Failed to install uv"
+        exit 1
+    }
+    
+    # Install PyTorch first
+    uv pip install "torch>=2.5.1" || {
+        echo "Error: Failed to install PyTorch"
+        exit 1
+    }
+    
+    # Install project dependencies
+    uv pip install --no-build-isolation -e .[all] || {
+        echo "Error: Failed to install project dependencies"
+        exit 1
+    }
+    
+    echo "Environment setup completed successfully"
+}
+
+# Function to handle Hugging Face authentication
+setup_hf_auth() {
+    # First check for token in environment variable
+    if [[ -z "${HF_TOKEN}" ]]; then
+        # If not in environment, check for config file
+        if [[ -f "${BASE_DIR}/.hf_token" ]]; then
+            export HF_TOKEN=$(cat "${BASE_DIR}/.hf_token")
+        else
+            echo "No Hugging Face token found in environment or config file."
+            echo "Please either:"
+            echo "1. Export HF_TOKEN environment variable"
+            echo "2. Create ${BASE_DIR}/.hf_token file with your token"
+            exit 1
+        fi
+    fi
+    
+    # Create or update huggingface-cli config
+    mkdir -p ~/.huggingface
+    echo "token=${HF_TOKEN}" > ~/.huggingface/token
+}
+
+# Model download function
+download_model() {
+    local model_name="$1"
+    local repo_id="${MODEL_REPOS[$model_name]}"
+    
+    echo "Downloading model: $model_name from $repo_id"
+    
+    # Setup authentication
+    setup_hf_auth
+    
+    # Create model directory
+    mkdir -p "${BASE_DIR}/models/${model_name}"
+    
+    # Download the model
+    huggingface-cli download --resume-download "$repo_id" --local-dir "${BASE_DIR}/models/${model_name}" || {
+        echo "Error: Failed to download model $model_name"
+        exit 1
+    }
+    
+    echo "Model downloaded successfully to: ${BASE_DIR}/models/${model_name}"
+}
+
+# Setup environment and download model
+setup_environment
+download_model "$MODEL_NAME"
+
+# Exit if setup only
+if [[ "$SETUP_ONLY" == true ]]; then
+    echo "Setup completed. Exiting as requested."
+    exit 0
+fi
 
 # Create a short abbreviation for the noise type to use in filenames
 if [[ "$NOISE_TYPE" == "gaussian" ]]; then
-  NOISE_ABBR="gs"
+    NOISE_ABBR="gs"
 else
-  NOISE_ABBR="un"
+    NOISE_ABBR="un"
 fi
 
 # Array of quantization options to loop through
@@ -71,13 +209,10 @@ QUANTIZATIONS=("None" "8bit" "4bit")
 # Array of noise levels to loop through
 NOISE_LEVELS=("1e-4" "1e-3" "3e-3" "5e-3" "1e-2")
 
-# Create a log directory
+# Create directories
 LOG_DIR="${OUTPUT_DIR}/logs"
-mkdir -p "$LOG_DIR"
-
-# Create a temp directory for job tracking
 TEMP_DIR="${OUTPUT_DIR}/tmp"
-mkdir -p "$TEMP_DIR"
+mkdir -p "$LOG_DIR" "$TEMP_DIR"
 
 # Create a file to track running jobs
 TRACKING_FILE="${TEMP_DIR}/running_jobs.txt"

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
         'console_scripts': [
             'adversarial-codegen=adversarial_codegen.run:main',
             'adversarial-codegen-test=adversarial_codegen.tests.integration_test.quick_test:main',
+            'adversarial-codegen-noise=adversarial_codegen.noise:main',
         ],
     },
 )


### PR DESCRIPTION
Add support for noise attack.

Main change:

- Add a python script to run noise attack.
- Add a shell script to automatically running noise attack, including:
  - automatically install dependency and download model.
  - run attack under different config in parallel
  - usage:
    ```bash
    export HF_TOKEN='your_token_here'
    bash run_noise.sh
    ```